### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/littlepeterr/2811a436-13b3-42ce-af89-2f93261bd852/60027edc-9b38-4805-9c7b-4b5b6df6f43d/_apis/work/boardbadge/5933e891-6a0b-4791-94f8-52111ad9198d)](https://dev.azure.com/littlepeterr/2811a436-13b3-42ce-af89-2f93261bd852/_boards/board/t/60027edc-9b38-4805-9c7b-4b5b6df6f43d/Microsoft.RequirementCategory)
 # SupermarketCheckout
 
 A supermarket checkout website example


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#203](https://dev.azure.com/littlepeterr/2811a436-13b3-42ce-af89-2f93261bd852/_workitems/edit/203). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.